### PR TITLE
Corregir comparación de cadenas en DiscountCalculator

### DIFF
--- a/debugging/week-01-missing-discount/src/com/walmarttech/discount/DiscountCalculator.java
+++ b/debugging/week-01-missing-discount/src/com/walmarttech/discount/DiscountCalculator.java
@@ -1,7 +1,7 @@
 public class DiscountCalculator {
 
     public double calculateDiscount(Customer customer, double totalAmount) {
-        if (customer.getMembershipLevel() == "Gold") {
+        if (customer.getMembershipLevel().equals("Gold")) {
             return totalAmount * 0.2; // 20% de descuento
         }
         return 0.0;


### PR DESCRIPTION
Se corrigió la comparación del nivel de membresía del cliente en DiscountCalculator cambiando el operador == por el método .equals() para comparar correctamente el contenido de cadenas en Java. Esto evita errores en la evaluación del nivel de membresía y asegura que el descuento se aplique adecuadamente.
